### PR TITLE
default categories has been seeded

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/create.blade.php
@@ -97,7 +97,6 @@
                                     </thead>
 
                                     <tbody>
-                                    @dd($configurableFamily->configurable_attributes)
                                         @foreach ($configurableFamily->configurable_attributes as $attribute)
                                             <tr>
                                                 <td>

--- a/packages/Webkul/Category/src/Database/Seeders/CategoryTableSeeder.php
+++ b/packages/Webkul/Category/src/Database/Seeders/CategoryTableSeeder.php
@@ -14,12 +14,31 @@ class CategoryTableSeeder extends Seeder
 
         $now = Carbon::now();
 
+        // Category 1
         DB::table('categories')->insert([
-            ['id' => '1','position' => '1','image' => NULL,'status' => '1','_lft' => '1','_rgt' => '14','parent_id' => NULL, 'created_at' => $now, 'updated_at' => $now]
+            ['id' => '1','position' => '1','image' => NULL,'status' => '1','_lft' => '6','_rgt' => '7','parent_id' => NULL, 'created_at' => $now, 'updated_at' => $now]
         ]);
 
         DB::table('category_translations')->insert([
-            ['id' => '1','name' => 'Root','slug' => 'root','description' => 'Root','meta_title' => '','meta_description' => '','meta_keywords' => '','category_id' => '1','locale' => 'en']
+            ['id' => '1','name' => 'Category 1','slug' => 'category-1','description' => 'category 1','meta_title' => '','meta_description' => '','meta_keywords' => '','category_id' => '1','locale' => 'en']
+        ]);
+
+        // Category 2
+        DB::table('categories')->insert([
+            ['id' => '2','position' => '2','image' => NULL,'status' => '1','_lft' => '8','_rgt' => '9','parent_id' => NULL, 'created_at' => $now, 'updated_at' => $now]
+        ]);
+
+        DB::table('category_translations')->insert([
+            ['id' => '2','name' => 'Category 2','slug' => 'category-2','description' => 'category 2','meta_title' => '','meta_description' => '','meta_keywords' => '','category_id' => '2','locale' => 'en']
+        ]);
+
+        // Category 3
+        DB::table('categories')->insert([
+            ['id' => '3','position' => '3','image' => NULL,'status' => '1','_lft' => '10','_rgt' => '11','parent_id' => NULL, 'created_at' => $now, 'updated_at' => $now]
+        ]);
+
+        DB::table('category_translations')->insert([
+            ['id' => '3','name' => 'Category 3','slug' => 'category-3','description' => 'category 3','meta_title' => '','meta_description' => '','meta_keywords' => '','category_id' => '3','locale' => 'en']
         ]);
     }
 }

--- a/packages/Webkul/Core/src/Database/Seeders/ChannelTableSeeder.php
+++ b/packages/Webkul/Core/src/Database/Seeders/ChannelTableSeeder.php
@@ -15,7 +15,6 @@ class ChannelTableSeeder extends Seeder
                 'id' => 1,
                 'code' => 'default',
                 'name' => 'Default',
-                'root_category_id' => 1,
                 'home_page_content' => '<p>@include("shop::home.slider") @include("shop::home.featured-products") @include("shop::home.new-products")</p><div class="banner-container"><div class="left-banner"><img src="https://s3-ap-southeast-1.amazonaws.com/cdn.uvdesk.com/website/1/201902045c581f9494b8a1.png" /></div><div class="right-banner"><img src="https://s3-ap-southeast-1.amazonaws.com/cdn.uvdesk.com/website/1/201902045c581fb045cf02.png" /> <img src="https://s3-ap-southeast-1.amazonaws.com/cdn.uvdesk.com/website/1/201902045c581fc352d803.png" /></div></div>',
                 'footer_content' => '<div class="list-container"><span class="list-heading">Quick Links</span><ul class="list-group"><li><a href="#">About Us</a></li><li><a href="#">Return Policy</a></li><li><a href="#">Refund Policy</a></li><li><a href="#">Terms and conditions</a></li><li><a href="#">Terms of Use</a></li><li><a href="#">Contact Us</a></li></ul></div><div class="list-container"><span class="list-heading">Connect With Us</span><ul class="list-group"><li><a href="#"><span class="icon icon-facebook"></span>Facebook </a></li><li><a href="#"><span class="icon icon-twitter"></span> Twitter </a></li><li><a href="#"><span class="icon icon-instagram"></span> Instagram </a></li><li><a href="#"> <span class="icon icon-google-plus"></span>Google+ </a></li><li><a href="#"> <span class="icon icon-linkedin"></span>LinkedIn </a></li></ul></div>',
                 'name' => 'Default',
@@ -27,7 +26,7 @@ class ChannelTableSeeder extends Seeder
                 'channel_id' => 1,
                 'currency_id' => 1,
             ]);
-        
+
         DB::table('channel_locales')->insert([
                 'channel_id' => 1,
                 'locale_id' => 1,


### PR DESCRIPTION
I seeded default categories, after I run php artisan db:seed --class=CategoryTableSeeder but it was not working. so I have to migrate:fresh --seed before I can get it done.

![Screenshot from 2019-11-22 13-04-39](https://user-images.githubusercontent.com/26380735/69424347-ab2e1b80-0d28-11ea-9326-c85f3c3ab8bb.png)

Still on the investigation concerning task 30.
I discovered that there was @dd which stop admin from creating new product which I removed it.
![Screenshot from 2019-11-22 10-16-13](https://user-images.githubusercontent.com/26380735/69424417-d87ac980-0d28-11ea-829e-22bc4428f755.png)
![Screenshot from 2019-11-22 10-48-49](https://user-images.githubusercontent.com/26380735/69424427-e16b9b00-0d28-11ea-81ce-f523a7a80a5b.png)

 